### PR TITLE
Use SlingContextImpl instead of AemContextImpl

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -24,6 +24,12 @@
   <body>
 
     <release version="1.2.0" date="not released">
+      <action type="update" dev="sseifert" issue="2">
+        Use SlingContextImpl for WCMIO_SLING instead of AemContextImpl to be usable with sling-mocks alone.
+      </action>
+      <action type="update" dev="sseifert" issue="1">
+        MockSlingExtensions.setRequestContext: Accept SlingContextImpl and not only AemContextImpl.
+      </action>
       <action type="update" dev="sseifert">
         Switch to Java 11 as minimum version.
       </action>

--- a/src/main/java/io/wcm/testing/mock/wcmio/sling/ContextPlugins.java
+++ b/src/main/java/io/wcm/testing/mock/wcmio/sling/ContextPlugins.java
@@ -21,6 +21,7 @@ package io.wcm.testing.mock.wcmio.sling;
 
 import org.apache.sling.testing.mock.osgi.context.AbstractContextPlugin;
 import org.apache.sling.testing.mock.osgi.context.ContextPlugin;
+import org.apache.sling.testing.mock.sling.context.SlingContextImpl;
 import org.jetbrains.annotations.NotNull;
 
 import io.wcm.sling.commons.caservice.impl.ContextAwareServiceResolverImpl;
@@ -28,7 +29,6 @@ import io.wcm.sling.commons.request.RequestContext;
 import io.wcm.sling.models.injectors.impl.AemObjectInjector;
 import io.wcm.sling.models.injectors.impl.ModelsImplConfiguration;
 import io.wcm.sling.models.injectors.impl.SlingObjectOverlayInjector;
-import io.wcm.testing.mock.aem.context.AemContextImpl;
 
 /**
  * Mock context plugins.
@@ -42,9 +42,9 @@ public final class ContextPlugins {
   /**
    * Context plugin for wcm.io Sling Extensions.
    */
-  public static final @NotNull ContextPlugin<AemContextImpl> WCMIO_SLING = new AbstractContextPlugin<AemContextImpl>() {
+  public static final @NotNull ContextPlugin<SlingContextImpl> WCMIO_SLING = new AbstractContextPlugin<SlingContextImpl>() {
     @Override
-    public void afterSetUp(@NotNull AemContextImpl context) throws Exception {
+    public void afterSetUp(@NotNull SlingContextImpl context) throws Exception {
       setUp(context);
     }
   };
@@ -53,7 +53,7 @@ public final class ContextPlugins {
    * Set up request context and Sling Models Extensions.
    * @param context Aem context
    */
-  static void setUp(AemContextImpl context) {
+  static void setUp(SlingContextImpl context) {
 
     // context-aware services
     context.registerInjectActivateService(new ContextAwareServiceResolverImpl());

--- a/src/main/java/io/wcm/testing/mock/wcmio/sling/MockSlingExtensions.java
+++ b/src/main/java/io/wcm/testing/mock/wcmio/sling/MockSlingExtensions.java
@@ -20,12 +20,12 @@
 package io.wcm.testing.mock.wcmio.sling;
 
 import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.testing.mock.sling.context.SlingContextImpl;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.osgi.annotation.versioning.ProviderType;
 
 import io.wcm.sling.commons.request.RequestContext;
-import io.wcm.testing.mock.aem.context.AemContextImpl;
 
 /**
  * Helps setting up a mock environment for wcm.io Sling Extensions.
@@ -42,7 +42,7 @@ public final class MockSlingExtensions {
    * @param context AEM Context
    * @param request Request
    */
-  public static void setRequestContext(@NotNull AemContextImpl context, @Nullable SlingHttpServletRequest request) {
+  public static void setRequestContext(@NotNull SlingContextImpl context, @Nullable SlingHttpServletRequest request) {
     MockRequestContext requestContext = (MockRequestContext)context.getService(RequestContext.class);
     if (requestContext != null) {
       requestContext.setRequest(request);

--- a/src/main/java/io/wcm/testing/mock/wcmio/sling/package-info.java
+++ b/src/main/java/io/wcm/testing/mock/wcmio/sling/package-info.java
@@ -20,5 +20,5 @@
 /**
  * Helps setting up mock environment for wcm.io Sling Commons and Sling Models Extensions.
  */
-@org.osgi.annotation.versioning.Version("2.0.0")
+@org.osgi.annotation.versioning.Version("3.0.0")
 package io.wcm.testing.mock.wcmio.sling;


### PR DESCRIPTION
* Use SlingContextImpl for WCMIO_SLING instead of AemContextImpl to be …usable with sling-mocks alone (Fixes #2).
* MockSlingExtensions.setRequestContext: Accept SlingContextImpl and not only AemContextImpl (Fixes #1).