### PR TITLE
Register services and Sling Models injectors in beforeSetUp 

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -24,6 +24,9 @@
   <body>
 
     <release version="1.2.0" date="not released">
+      <action type="update" dev="sseifert">
+        Register services and Sling Models injectors in beforeSetUp to ensure they are registered before auto-detection and registration of Sling Models from classpath takes place.
+      </action>
       <action type="update" dev="sseifert" issue="2">
         Use SlingContextImpl for WCMIO_SLING instead of AemContextImpl to be usable with sling-mocks alone.
       </action>

--- a/src/main/java/io/wcm/testing/mock/wcmio/sling/ContextPlugins.java
+++ b/src/main/java/io/wcm/testing/mock/wcmio/sling/ContextPlugins.java
@@ -43,8 +43,12 @@ public final class ContextPlugins {
    * Context plugin for wcm.io Sling Extensions.
    */
   public static final @NotNull ContextPlugin<SlingContextImpl> WCMIO_SLING = new AbstractContextPlugin<SlingContextImpl>() {
+    /*
+     * use beforeSetUp here instead of afterSetUp to ensure sling models injectors are registered
+     * before the models are auto-detected from classpath.
+     */
     @Override
-    public void afterSetUp(@NotNull SlingContextImpl context) throws Exception {
+    public void beforeSetUp(@NotNull SlingContextImpl context) throws Exception {
       setUp(context);
     }
   };


### PR DESCRIPTION
to ensure they are registered before auto-detection and registration of Sling Models from classpath takes place.

Fixes https://github.com/wcm-io/io.wcm.testing.aem-mock/issues/5